### PR TITLE
Refactored ctor assignment of EdgeDiagnosticsAdapter.IsServerRunning for clarity

### DIFF
--- a/EdgeDiagnosticsAdapter/EdgeDiagnosticsAdapter.cpp
+++ b/EdgeDiagnosticsAdapter/EdgeDiagnosticsAdapter.cpp
@@ -27,14 +27,12 @@ EdgeDiagnosticsAdapter::EdgeDiagnosticsAdapter(_In_ LPCWSTR rootPath)
 		// Create websocket thread
 		m_webSocketHander = ::make_shared<WebSocketHandler>(rootPath, m_hWnd);
 		boost::thread serverThread(&WebSocketHandler::RunServer, m_webSocketHander);
-		this->IsServerRunning = true;
+		this->IsServerRunning = m_webSocketHander->IsServerListening;
 	}
 	catch(exception const &e)
 	{
 		this->IsServerRunning = false;
 	}
-
-	this->IsServerRunning = this->IsServerRunning  && m_webSocketHander->IsServerListening;
 }
 
 EdgeDiagnosticsAdapter::~EdgeDiagnosticsAdapter()


### PR DESCRIPTION
The positive-case assignment of IsServerRunning was a little confusing as I read through the code, so I've tweaked it to make a little more obvious (to me, at least). The only behavior this might change is if `m_webSocketHander->IsServerListening` can throw an exception (which in the current implementation, it can't)

I realise this is a bit of a token PR, so feel free to reject the PR and simply apply the change as part of your next internal commits.